### PR TITLE
sidesteps exception when other is not IP instance in IP.__cmp__()

### DIFF
--- a/IPy.py
+++ b/IPy.py
@@ -703,7 +703,7 @@ class IPint:
         0
 
         """
-	if other in [None, '']:
+	if not other:
             return -2
 
         # Im not really sure if this is "the right thing to do"


### PR DESCRIPTION
Based on your comment in issue #2 you probably don't want this patch.
This change is required for my project, so I thought I'd offer it upstream in case you changed your mind.

The adjustment was to bail out of IP.__cmp__() early "if not other". While this is inelegant, I can't afford to have an exception raised when simply comparing an IP instance to a non-IP instance. 

In my case the comparison is being made by django framework validation code that is out of my control. I'm continuing to look for ways (on the django side of the problem) to sidestep or handle the exception, but so far I've come up short.
