### PR TITLE
Fixed Exception when compared to None

### DIFF
--- a/IPy.py
+++ b/IPy.py
@@ -740,7 +740,8 @@ class IPint(object):
 
         """
         if other is None:
-            return False
+            return 1
+
         if not isinstance(other, IPint):
             raise TypeError
         


### PR DESCRIPTION
When compared to None it shouldn't raise an Exception, instead I simply claim that None is smaller.
