### PR TITLE
Add fuzz testing

### DIFF
--- a/test/test_IPy.py
+++ b/test/test_IPy.py
@@ -16,8 +16,6 @@ import IPy
 import unittest
 import random
 
-testloops = 250
-
 class parseAddress(unittest.TestCase):
     okValues = [('FEDC:BA98:7654:3210:FEDC:BA98:7654:3210', 338770000845734292534325025077361652240),
                 ('FEDCBA9876543210FEDCBA9876543210', 338770000845734292534325025077361652240),
@@ -201,21 +199,6 @@ class _intToIP(unittest.TestCase):
         self.assertRaises(ValueError, IPy.intToIp, 1, 5)
         self.assertRaises(ValueError, IPy.intToIp, 1, 7)
         self.assertRaises(ValueError, IPy.intToIp, 1, 8)
-
-class ParseAndBack(unittest.TestCase):
-    def testRandomValuesv4(self):
-        for i in range(testloops):
-            question = random.randrange(0x7fffffff) + random.randrange(0x7fffffff)
-            self.assertEqual(IPy.parseAddress(IPy.intToIp(question, 4)), (question, 4), hex(question))
-
-    def testRandomValuesv6(self):
-        for i in range(testloops):
-            question = ((random.randrange(0x7fffffff) + random.randrange(0x7fffffff)) +
-                        ((random.randrange(0x7fffffff) + random.randrange(0x7fffffff)) << 32) +
-                        ((random.randrange(0x7fffffff) + random.randrange(0x7fffffff)) << 64) +
-                        ((random.randrange(0x7fffffff) + random.randrange(0x7fffffff)) << 96))
-            self.assertEqual(IPy.parseAddress(IPy.intToIp(question, 6)), (question, 6), hex(question))
-
 
 class _countXBits(unittest.TestCase):
     def testCount1Bits(self):

--- a/test/test_fuzz.py
+++ b/test/test_fuzz.py
@@ -1,0 +1,106 @@
+"""Fuzing for IPy.py"""
+
+# TODO: unify assert / FilIf usage
+
+import sys
+import functools
+import itertools
+sys.path.append('.')
+sys.path.append('..')
+
+import IPy
+import unittest
+import random
+
+# on Python-2.7 and higher, we use load_tests to multiply out the test cases so that unittest
+# represents each as an individual test case.
+def iterate_27(n):
+    def wrap(func):
+        func.iterations = n
+        return func
+    return wrap
+
+def load_tests(loader, tests, pattern):
+    def expand(tests):
+        if isinstance(tests, unittest.TestCase):
+            method_name = tests._testMethodName
+            meth = getattr(tests, method_name)
+            if hasattr(meth, 'iterations'):
+                tests = unittest.TestSuite(type(tests)(method_name) for i in xrange(meth.iterations))
+        else:
+            tests = unittest.TestSuite(expand(t) for t in tests)
+        return tests
+    return expand(tests)
+
+# On older Pythons, we run the requisite iterations directly, in a single test case.
+def iterate_old(n):
+    def wrap(func):
+        @functools.wraps(func)
+        def replacement(*args):
+            for i in xrange(n):
+                func(*args)
+        return replacement
+    return wrap
+
+if sys.version_info >= (2,7):
+    iterate = iterate_27
+else:
+    iterate = iterate_old
+
+# utilities
+
+def random_ipv4_prefix():
+    prefixlen = random.randrange(32)
+    int_ip = random.randrange(IPy.MAX_IPV4_ADDRESS)
+    int_ip &= 0xffffffff << (32-prefixlen)
+    return IPy.IP('.'.join(map(str, (int_ip >> 24,
+                                    (int_ip >> 16) & 0xff,
+                                    (int_ip >> 8) & 0xff,
+                                    int_ip & 0xff)))
+                           + '/%d' % prefixlen)
+
+# tests
+
+class ParseAndBack(unittest.TestCase):
+
+    @iterate(500)
+    def testRandomValuesv4(self):
+        question = random.randrange(0xffffffff)
+        self.assertEqual(IPy.parseAddress(IPy.intToIp(question, 4)), (question, 4), hex(question))
+
+    @iterate(500)
+    def testRandomValuesv6(self):
+        question = random.randrange(0xffffffffffffffffffffffffffffffff)
+        self.assertEqual(IPy.parseAddress(IPy.intToIp(question, 6)), (question, 6), hex(question))
+
+class TestIPSet(unittest.TestCase):
+
+    @iterate(1000)
+    def testRandomContains(self):
+        prefixes = [random_ipv4_prefix() for i in xrange(random.randrange(50))]
+        question = random_ipv4_prefix()
+        answer = any(question in pfx for pfx in prefixes)
+        ipset = IPy.IPSet(prefixes)
+        self.assertEqual(question in ipset, answer,
+                "%s in %s != %s" % (question, ipset, answer))
+        
+
+    @iterate(1000)
+    def testRandomDisjoint(self):
+        prefixes1 = [random_ipv4_prefix() for i in xrange(random.randrange(50))]
+        prefixes2 = [random_ipv4_prefix() for i in xrange(random.randrange(50))]
+        # test disjointnes the stupid way
+        disjoint = True
+        for p1, p2 in itertools.product(prefixes1, prefixes2):
+            if p1 in p2 or p2 in p1:
+                disjoint = False
+                break
+        ipset1 = IPy.IPSet(prefixes1)
+        ipset2 = IPy.IPSet(prefixes2)
+        self.assertEqual(ipset1.isdisjoint(ipset2), disjoint,
+                "%s.isdisjoint(%s) != %s" % (ipset1, ipset2, disjoint))
+        self.assertEqual(ipset2.isdisjoint(ipset1), disjoint,
+                "%s.isdisjoint(%s) != %s" % (ipset2, ipset1, disjoint))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#25 unveils a pretty serious error, for a library that should be pretty nearly always correct.

It's pretty trivial to automatically invent test cases for a library like this.  For `__contains__`, for example, it'd be easy to generate a list of random IP prefixes, then either pick a query prefix that's within one of those prefixes, or that is _not_ within one of them.  Then call `__contains__` and verify it returns True or False, respectively.

Running a few hundred iterations of this on every run of the tests would, eventually, find errors of this sort.  Especially if it runs in travis :)
