### PR TITLE
IPSet now accepts more types

### DIFF
--- a/IPy.py
+++ b/IPy.py
@@ -1028,13 +1028,9 @@ class IPSet(collections.MutableSet):
         if not isinstance(iterable, collections.Iterable):
             raise TypeError("'%s' object is not iterable" % type(iterable).__name__)
         
-        # Make sure we only accept IP objects
-        for prefix in iterable:
-            if not isinstance(prefix, IP):
-                raise ValueError('Only IP objects can be added to an IPSet')
-            
         # Store and optimize
-        self.prefixes = iterable[:]
+        self.prefixes = [(IP(prefix) if not isinstance(prefix, IP) else prefix)
+                         for prefix in iterable]
         self.optimize()
             
     def __contains__(self, ip):

--- a/test/test_IPy.py
+++ b/test/test_IPy.py
@@ -862,6 +862,25 @@ class IPSetChecks(unittest.TestCase):
         self.assertFalse(IPy.IPSet([IPy.IP('1.1.1.1'), IPy.IP('1.1.1.3'), IPy.IP('1.1.2.0/24')])
                 .isdisjoint(IPy.IPSet([IPy.IP('1.1.2.2'), IPy.IP('1.1.1.4')])))
 
+    def testInitialization(self):
+        # Initialize with list of strings is the same if it is list of
+        # IP objects of the same strings
+        self.assertEqual(
+            IPy.IPSet([IPy.IP('10.0.0.0/8'), IPy.IP('128.0.0.0/1')]),
+            IPy.IPSet(['10.0.0.0/8', '128.0.0.0/1']),
+        )
+
+        # Initialize from generator expressions
+        self.assertEqual(
+            IPy.IPSet([IPy.IP('10.0.0.0/8'), IPy.IP('128.0.0.0/1')]),
+            IPy.IPSet(prefix for prefix in ('10.0.0.0/8', '128.0.0.0/1')),
+        )
+
+        self.assertRaises(ValueError, IPy.IPSet, ['Random string'])
+        self.assertRaises(TypeError, IPy.IPSet, [None])
+        self.assertRaises(TypeError, IPy.IPSet, [1.5])
+
+
 class RegressionTest(unittest.TestCase):
     def testNulNetmask(self):
         ip = timeout(IPy.IP, ["0.0.0.0/0.0.0.0"], timeout_duration=0.250, default=None)


### PR DESCRIPTION
- It can accept any type of iterables not only lists
- The iterable can have not only IP objects but also strings

Related to #54 