### PR TITLE
Fix DeprecationWarning regarding collections.abc and isAlive.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ python:
   - "3.7-dev"
   - "3.8-dev"
   - "nightly"
-script: nosetests -e fuzz
+install: pip install pytest
+script: pytest -k "not fuzz"

--- a/IPy.py
+++ b/IPy.py
@@ -9,9 +9,12 @@ https://github.com/haypo/python-ipy
 __version__ = '1.00'
 
 import bisect
-import collections
 import sys
 import types
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc
 
 # Definition of the Ranges for IPv4 IPs
 # this should include www.iana.org/assignments/ipv4-address-space
@@ -1022,10 +1025,10 @@ class IP(IPint):
         raise ValueError("%s cannot be converted to an IPv4 address."
                          % repr(self))
 
-class IPSet(collections.MutableSet):
+class IPSet(collections_abc.MutableSet):
     def __init__(self, iterable=[]):
         # Make sure it's iterable, otherwise wrap
-        if not isinstance(iterable, collections.Iterable):
+        if not isinstance(iterable, collections_abc.Iterable):
             raise TypeError("'%s' object is not iterable" % type(iterable).__name__)
         
         # Make sure we only accept IP objects
@@ -1099,7 +1102,7 @@ class IPSet(collections.MutableSet):
 
     def add(self, value):
         # Make sure it's iterable, otherwise wrap
-        if not isinstance(value, collections.Iterable):
+        if not isinstance(value, collections_abc.Iterable):
             value = [value]
         
         # Check type
@@ -1113,7 +1116,7 @@ class IPSet(collections.MutableSet):
     
     def discard(self, value):
         # Make sure it's iterable, otherwise wrap
-        if not isinstance(value, collections.Iterable):
+        if not isinstance(value, collections_abc.Iterable):
             value = [value]
             
         # This is much faster than iterating over the addresses

--- a/test/test_IPy.py
+++ b/test/test_IPy.py
@@ -788,7 +788,11 @@ def timeout(func, args=(), kwargs={}, timeout_duration=1, default=None):
     it.setDaemon(True)
     it.start()
     it.join(timeout_duration)
-    if it.isAlive():
+    if hasattr(it, 'is_alive'):
+        is_alive = it.is_alive()
+    else:
+        is_alive = it.isAlive()
+    if is_alive:
         return default
     else:
         return it.result


### PR DESCRIPTION
This fixes following deprecation warnings that would be errors in Python 3.9

```
IPy.py:1025
  /home/xtreak/stuff/python/python-ipy/IPy.py:1025: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    class IPSet(collections.MutableSet):

IPy.py:1028
  /home/xtreak/stuff/python/python-ipy/IPy.py:1028: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    if not isinstance(iterable, collections.Iterable):

test/test_IPy.py::RegressionTest::testNulNetmask
  /home/xtreak/stuff/python/python-ipy/test/test_IPy.py:791: DeprecationWarning: isAlive() is deprecated, use is_alive() instead
    if it.isAlive():

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

Fixes #62 