### PR TITLE
Replace unmaintained nose with pytest to support Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ python:
   - "3.7-dev"
   - "3.8-dev"
   - "nightly"
-script: nosetests -e fuzz
+install: pip install pytest
+script: pytest -k "not fuzz"


### PR DESCRIPTION
`nightly` on the CI now points to Python 3.9 alpha.

Here's a `master` build from today that fails on `nightly` because nose doesn't support 3.9:

```
  File "/home/travis/virtualenv/python3.9-dev/lib/python3.9/site-packages/nose/suite.py", line 106, in _set_tests
    if isinstance(tests, collections.Callable) and not is_suite:
AttributeError: module 'collections' has no attribute 'Callable'
```

https://travis-ci.org/hugovk/python-ipy/jobs/639633752

Nose is in maintenance mode, in fact it's not had any updates in 4 years:
* https://nose.readthedocs.io/en/latest/
* https://github.com/nose-devs/nose/

This PR replaces nose with the more modern pytest.
