### PR TITLE
Use `Thread.is_alive()` not `Thread.isAlive()` for Python 3.9

### DIFF
--- a/test/test_IPy.py
+++ b/test/test_IPy.py
@@ -788,7 +788,7 @@ def timeout(func, args=(), kwargs={}, timeout_duration=1, default=None):
     it.setDaemon(True)
     it.start()
     it.join(timeout_duration)
-    if it.isAlive():
+    if it.is_alive():
         return default
     else:
         return it.result


### PR DESCRIPTION
Thread.is_alive() has been available since Python 2.6, and
Thread.isAlive() has been removed in Python 3.9.

Signed-off-by: Adam Williamson <awilliam@redhat.com>