### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 dist: xenial
+arch:
+  - amd64
+  - ppc64le
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/python-ipy/builds/191030645 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!