### PR TITLE
Release 1.02 Fix a bug: last_ip can't be compressed

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Version 1.02 (2021-01-20)
+------------
+ * Fix a bug: `last_ip` can't be compressed
+
 Version 1.01 (2020-12-01)
 ------------
  * Update to support up to Python 3.9

--- a/IPy.py
+++ b/IPy.py
@@ -6,7 +6,7 @@ Further Information might be available at:
 https://github.com/haypo/python-ipy
 """
 
-__version__ = '1.01'
+__version__ = '1.02'
 
 import bisect
 import types
@@ -403,7 +403,12 @@ class IPint(object):
                     hextets.append('')
                 if compressionpos == 0:
                     hextets = [''] + hextets
-                return ':'.join(hextets) + self._printPrefix(wantprefixlen)
+                # fix the bug: `last_ip` can't be compressed
+                if wantprefixlen == 3:
+                    _last = "-%s" % (IPint(self.ip + self.len() - 1).strCompressed())
+                else:
+                    _last = self._printPrefix(wantprefixlen)
+                return ':'.join(hextets) + _last
             else:
                 return self.strNormal(0) + self._printPrefix(wantprefixlen)
 

--- a/README.rst
+++ b/README.rst
@@ -177,7 +177,7 @@ unique address ranges and will aggregate overlapping ranges. ::
 Compatibility and links
 =======================
 
-IPy 1.01 works on Python version 2.6 - 3.7.
+IPy 1.02 works on Python version 2.6 - 3.7.
 
 The IP module should work in Python 2.5 as long as the subtraction operation
 is not used. IPSet requires features of the collecitons class which appear

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from __future__ import with_statement
 import sys
 from distutils.core import setup
 
-VERSION = '1.01'
+VERSION = '1.02'
 
 options = {}
 


### PR DESCRIPTION
```python
>>>IP('2001:0658:022a:cafe:0200::/120').strCompressed(3)
```

expected:

`2001:658:22a:cafe:200::-2001:658:22a:cafe:200::ff`

but Release 1.01 output:

`2001:658:22a:cafe:200::-2001:0658:022a:cafe:0200:0000:0000:00ff`

Now we can fix it!