### PR TITLE
Update IPy.py to address mutableset missing from collections in python3.10+

### DIFF
--- a/IPy.py
+++ b/IPy.py
@@ -11,9 +11,19 @@ __version__ = '1.01'
 import bisect
 import types
 try:
-    import collections.abc as collections_abc
+    import collections 
+    if sys.version_info.major == 3 and sys.version_info.minor >= 10
+
+        from collections.abc import MutableMapping
+    else 
+        from collections import MutableMapping
 except ImportError:
-    import collections as collections_abc
+    import collections 
+    if sys.version_info.major == 3 and sys.version_info.minor >= 10
+
+        from collections.abc import MutableMapping
+    else 
+        from collections import MutableMapping
 
 # Definition of the Ranges for IPv4 IPs
 # this should include www.iana.org/assignments/ipv4-address-space

--- a/IPy.py
+++ b/IPy.py
@@ -10,20 +10,11 @@ __version__ = '1.01'
 
 import bisect
 import types
-try:
-    import collections 
-    if sys.version_info.major == 3 and sys.version_info.minor >= 10
-
-        from collections.abc import MutableMapping
-    else 
-        from collections import MutableMapping
-except ImportError:
-    import collections 
-    if sys.version_info.major == 3 and sys.version_info.minor >= 10
-
-        from collections.abc import MutableMapping
-    else 
-        from collections import MutableMapping
+import collections 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10
+    from collections.abc import MutableMapping
+else 
+    from collections import MutableMapping
 
 # Definition of the Ranges for IPv4 IPs
 # this should include www.iana.org/assignments/ipv4-address-space


### PR DESCRIPTION
python 3.10 has removed the mutablemapping from the collections module which causes ipy to fail with 
```
    from IPy import IP as ipadd
  File "/usr/lib/python3.10/site-packages/IPy.py", line 1025, in <module>
    class IPSet(collections.MutableSet):
AttributeError: module 'collections' has no attribute 'MutableSet'
```
the proposed code change is the suggested work-around for the problem

I was in a bit of a rush when I PRd this and tbh looking at the original try/except logic, it can probably just be removed since the new code should accomplish what I think the original intent was. 